### PR TITLE
Fixes ES5 support for catch

### DIFF
--- a/transliterate.js
+++ b/transliterate.js
@@ -17,7 +17,7 @@ function objAssign(objs) {
 			var d = r;
 			Object.keys(o).forEach(function (k) { d[k] = o[k]; });
 			return d;
-		} catch { return r; }
+		} catch (_) { return r; }
     	}, {});
 };
 


### PR DESCRIPTION
Fixes the error:

> Unexpected token '{'. Expected '(' to start a 'catch' target.

See Sentry 1910023755