### PR TITLE
Bundle with microbundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+dist

--- a/package.json
+++ b/package.json
@@ -1,49 +1,52 @@
 {
-	"name": "sluga",
-	"version": "0.1.4",
-	"description": "Slugify a string",
-	"license": "MIT",
-	"repository": "shuding/sluga",
-	"author": {
-		"name": "Sindre Sorhus",
-		"email": "sindresorhus@gmail.com",
-		"url": "https://sindresorhus.com"
-	},
-	"engines": {
-		"node": ">=10"
-	},
-	"files": [
-		"index.js",
-		"index.d.ts",
-		"transliterate.js",
-		"replacements.js"
-	],
-	"keywords": [
-		"string",
-		"slugify",
-		"slug",
-		"url",
-		"url-safe",
-		"urlify",
-		"transliterate",
-		"transliteration",
-		"deburr",
-		"unicode",
-		"ascii",
-		"text",
-		"decamelize",
-		"pretty",
-		"clean",
-		"filename",
-		"id"
-	],
-	"dependencies": {
-		"escape-string-regexp": "^2.0.0",
-		"lodash.deburr": "^4.1.0"
-	},
-	"devDependencies": {
-		"ava": "^2.4.0",
-		"tsd": "^0.11.0",
-		"xo": "^0.26.1"
-	}
+  "name": "sluga",
+  "version": "0.1.4",
+  "description": "Slugify a string",
+  "license": "MIT",
+  "repository": "shuding/sluga",
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com"
+  },
+  "engines": {
+    "node": ">=10"
+  },
+  "files": [
+    "dist"
+  ],
+	"source": "./index.js",
+	"main": "dist/index.js",
+  "scripts": {
+    "build": "microbundle *.js --compress --no-sourcemap"
+  },
+  "keywords": [
+    "string",
+    "slugify",
+    "slug",
+    "url",
+    "url-safe",
+    "urlify",
+    "transliterate",
+    "transliteration",
+    "deburr",
+    "unicode",
+    "ascii",
+    "text",
+    "decamelize",
+    "pretty",
+    "clean",
+    "filename",
+    "id"
+  ],
+  "dependencies": {
+    "escape-string-regexp": "^2.0.0",
+    "lodash.deburr": "^4.1.0"
+  },
+  "devDependencies": {
+    "ava": "^2.4.0",
+    "microbundle": "^0.13.0",
+    "tsd": "^0.11.0",
+    "xo": "^0.26.1"
+  }
 }


### PR DESCRIPTION
Before:

```
1347B index.js
10672B replacements.js
1495B transliterate.js
``` 

After:

```
753B index.js (56% smaller)
7494B replacements.js (35% smaller)
790B transliterate.js  (62% smaller)
```

Review with whitespace off (ran prettier)